### PR TITLE
Add in GH actions to run workflows

### DIFF
--- a/.github/workflows/test-osw.yml
+++ b/.github/workflows/test-osw.yml
@@ -1,0 +1,25 @@
+name: Test OSW
+on: push
+
+jobs:
+  test-osw:
+    runs-on: ubuntu-latest
+    container:  nrel/openstudio:3.2.1
+    steps:
+    - name: check out repository
+      uses: actions/checkout@v2
+    - name: enviroment info
+      shell: bash 
+      run: |
+          openstudio --version
+          ruby -v
+          bundle -v
+    - name: install dependencies
+      shell: bash 
+      run: |
+          gem install parallel
+          gem install rubyXL
+    - name: install dependencies
+      shell: bash 
+      run: |
+          ruby run_all_generate_reports.rb 

--- a/.github/workflows/test-osw.yml
+++ b/.github/workflows/test-osw.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
           gem install parallel
           gem install rubyXL
-    - name: install dependencies
+    - name: run workflows
       shell: bash 
       run: |
           ruby run_all_generate_reports.rb 


### PR DESCRIPTION
This add in a basic GH actions to run osw workflows using the latest OpenStudio 3.2.1 container image.  

@DavidGoldwasser  Only takes about ~12 min to run the workflows so this will easy run using Actions.  This currently does not save any artifacts after the run. Do you want any data to be saved? 

